### PR TITLE
Key_strength bug fix

### DIFF
--- a/osquery/tables/system/windows/certificates.cpp
+++ b/osquery/tables/system/windows/certificates.cpp
@@ -186,7 +186,7 @@ void enumerateCertStore(const HCERTSTORE& certStore,
 
     r["key_usage"] = getKeyUsage(certContext->pCertInfo);
 
-    r["key_strength"] = INTEGER(certContext->cbCertEncoded);
+    r["key_strength"] = INTEGER((certContext->pCertInfo->SubjectPublicKeyInfo.PublicKey.cbData) * 8);
 
     certBuff.clear();
     getCertCtxProp(certContext, CERT_KEY_IDENTIFIER_PROP_ID, certBuff);


### PR DESCRIPTION
Modifying the "key_strength" query to retrieve the bit length of the encoded public key.

Fixing issue: #5103

![key_strength_post](https://user-images.githubusercontent.com/37255169/48811156-814bae80-ecfa-11e8-847d-227ef4de487f.PNG)


